### PR TITLE
Scm scaling - examples in scm-frontend/backend and some ansible install updates

### DIFF
--- a/ansible/playbooks/group_vars/all.yml
+++ b/ansible/playbooks/group_vars/all.yml
@@ -76,3 +76,8 @@ namespace_knativeserving: knative-serving
 namespace_knativeeventing: knative-eventing
 ##########################################
 
+
+####### KEDA ##############
+keda_namepsace: keda
+###########################
+

--- a/ansible/playbooks/install.yml
+++ b/ansible/playbooks/install.yml
@@ -14,6 +14,7 @@
   tasks:
   - include: tasks/amq-streams.yml
 #  - include: tasks/knative.yml
+  - include: tasks/keda.yml
   - include: tasks/scm-backend.yml
   - include: tasks/scm-frontend.yml
   - include: tasks/monitoring_operators.yml

--- a/ansible/playbooks/keda.yml
+++ b/ansible/playbooks/keda.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Deploy KEDA
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  run_once: true
+  vars_files:
+    - group_vars/all.yml
+  # vars:
+  #   ACTION: install
+  #   #ACTION: uninstall
+
+  tasks:
+    - include: tasks/keda.yml

--- a/ansible/playbooks/tasks/amq-streams.yml
+++ b/ansible/playbooks/tasks/amq-streams.yml
@@ -1,6 +1,6 @@
 ---
 
-1)  AMQ Streams Operator
+# 1)  AMQ Streams Operator
 - set_fact:
     namespace: "{{ project_name }}"
     work_dir_name: "amq-streams-operator"
@@ -18,7 +18,7 @@
     ACTION is defined and
     ACTION|trim() == "uninstall"
 
-2) AMQ Streams Kafka cluster
+# # 2) AMQ Streams Kafka cluster
 - set_fact:
     namespace: "{{ project_name }}"
     resources_dir: "{{ resources_base_dir }}/amq-streams"
@@ -37,7 +37,7 @@
     ACTION is defined and
     ACTION|trim() == "uninstall"
 
-3) AMQ Streams Topics
+# 3) AMQ Streams Topics
 - set_fact:
     namespace: "{{ project_name }}"
     work_dir_name: "kafka_topics"

--- a/ansible/playbooks/tasks/amq-streams.yml
+++ b/ansible/playbooks/tasks/amq-streams.yml
@@ -18,7 +18,7 @@
     ACTION is defined and
     ACTION|trim() == "uninstall"
 
-# # 2) AMQ Streams Kafka cluster
+# 2) AMQ Streams Kafka cluster
 - set_fact:
     namespace: "{{ project_name }}"
     resources_dir: "{{ resources_base_dir }}/amq-streams"

--- a/ansible/playbooks/tasks/amq-streams.yml
+++ b/ansible/playbooks/tasks/amq-streams.yml
@@ -1,80 +1,80 @@
 ---
 
 # 1)  AMQ Streams Operator
-- set_fact:
-    namespace: "{{ project_name }}"
-    work_dir_name: "amq-streams-operator"
-- include_role:
-    name: ../roles/amq_streams_operator
-  when: >
-    ACTION is not defined or
-    ACTION is none or
-    ACTION|trim() == "" or
-    ACTION|trim() == "install"
-- include_role:
-    name: ../roles/amq_streams_operator
-    tasks_from: uninstall
-  when: >
-    ACTION is defined and
-    ACTION|trim() == "uninstall"
+# - set_fact:
+#     namespace: "{{ project_name }}"
+#     work_dir_name: "amq-streams-operator"
+# - include_role:
+#     name: ../roles/amq_streams_operator
+#   when: >
+#     ACTION is not defined or
+#     ACTION is none or
+#     ACTION|trim() == "" or
+#     ACTION|trim() == "install"
+# - include_role:
+#     name: ../roles/amq_streams_operator
+#     tasks_from: uninstall
+#   when: >
+#     ACTION is defined and
+#     ACTION|trim() == "uninstall"
 
 # 2) AMQ Streams Kafka cluster
-- set_fact:
-    namespace: "{{ project_name }}"
-    resources_dir: "{{ resources_base_dir }}/amq-streams"
-    work_dir_name: "kafka_cluster"
-- include_role:
-    name: ../roles/kafka_cluster
-  when: >
-    ACTION is not defined or
-    ACTION is none or
-    ACTION|trim() == "" or
-    ACTION|trim() == "install"
-- include_role:
-    name: ../roles/kafka_cluster
-    tasks_from: uninstall
-  when: >
-    ACTION is defined and
-    ACTION|trim() == "uninstall"
+# - set_fact:
+#     namespace: "{{ project_name }}"
+#     resources_dir: "{{ resources_base_dir }}/amq-streams"
+#     work_dir_name: "kafka_cluster"
+# - include_role:
+#     name: ../roles/kafka_cluster
+#   when: >
+#     ACTION is not defined or
+#     ACTION is none or
+#     ACTION|trim() == "" or
+#     ACTION|trim() == "install"
+# - include_role:
+#     name: ../roles/kafka_cluster
+#     tasks_from: uninstall
+#   when: >
+#     ACTION is defined and
+#     ACTION|trim() == "uninstall"
 
 # 3) AMQ Streams Topics
-- set_fact:
-    namespace: "{{ project_name }}"
-    work_dir_name: "kafka_topics"
-- include_role:
-    name: ../roles/kafka_topics
-  when: >
-    ACTION is not defined or
-    ACTION is none or
-    ACTION|trim() == "" or
-    ACTION|trim() == "install"
-- include_role:
-    name: ../roles/kafka_topics
-    tasks_from: uninstall
-  when: >
-    ACTION is defined and
-    ACTION|trim() == "uninstall"
+# - set_fact:
+#     namespace: "{{ project_name }}"
+#     work_dir_name: "kafka_topics"
+# - include_role:
+#     name: ../roles/kafka_topics
+#   when: >
+#     ACTION is not defined or
+#     ACTION is none or
+#     ACTION|trim() == "" or
+#     ACTION|trim() == "install"
+# - include_role:
+#     name: ../roles/kafka_topics
+#     tasks_from: uninstall
+#   when: >
+#     ACTION is defined and
+#     ACTION|trim() == "uninstall"
 
 
 
-# 4) AMQ Streams Kafka-Connect
-- set_fact:
-    namespace: "{{ project_name }}"
-    work_dir_name: "kafka_connect"
-    resources_dir: "{{ resources_base_dir }}/kafka-connect"
-- include_role:
-    name: ../roles/openshift_kafka_connect
-  when: >
-    ACTION is not defined or
-    ACTION is none or
-    ACTION|trim() == "" or
-    ACTION|trim() == "install"
-- include_role:
-    name: ../roles/openshift_kafka_connect
-    tasks_from: uninstall
-  when: >
-    ACTION is defined and
-    ACTION|trim() == "uninstall"
+# # 4) AMQ Streams Kafka-Connect
+# - set_fact:
+#     namespace: "{{ project_name }}"
+#     work_dir_name: "kafka_connect"
+#     resources_dir: "{{ resources_base_dir }}/kafka-connect"
+# - include_role:
+#     name: ../roles/openshift_kafka_connect
+#   when: >
+#     ACTION is not defined or
+#     ACTION is none or
+#     ACTION|trim() == "" or
+#     ACTION|trim() == "install"
+# - include_role:
+#     name: ../roles/openshift_kafka_connect
+#     tasks_from: uninstall
+#   when: >
+#     ACTION is defined and
+#     ACTION|trim() == "uninstall"
 
 # 5) Kafdrop
 - set_fact:

--- a/ansible/playbooks/tasks/amq-streams.yml
+++ b/ansible/playbooks/tasks/amq-streams.yml
@@ -1,80 +1,80 @@
 ---
 
-# 1)  AMQ Streams Operator
-# - set_fact:
-#     namespace: "{{ project_name }}"
-#     work_dir_name: "amq-streams-operator"
-# - include_role:
-#     name: ../roles/amq_streams_operator
-#   when: >
-#     ACTION is not defined or
-#     ACTION is none or
-#     ACTION|trim() == "" or
-#     ACTION|trim() == "install"
-# - include_role:
-#     name: ../roles/amq_streams_operator
-#     tasks_from: uninstall
-#   when: >
-#     ACTION is defined and
-#     ACTION|trim() == "uninstall"
+1)  AMQ Streams Operator
+- set_fact:
+    namespace: "{{ project_name }}"
+    work_dir_name: "amq-streams-operator"
+- include_role:
+    name: ../roles/amq_streams_operator
+  when: >
+    ACTION is not defined or
+    ACTION is none or
+    ACTION|trim() == "" or
+    ACTION|trim() == "install"
+- include_role:
+    name: ../roles/amq_streams_operator
+    tasks_from: uninstall
+  when: >
+    ACTION is defined and
+    ACTION|trim() == "uninstall"
 
-# 2) AMQ Streams Kafka cluster
-# - set_fact:
-#     namespace: "{{ project_name }}"
-#     resources_dir: "{{ resources_base_dir }}/amq-streams"
-#     work_dir_name: "kafka_cluster"
-# - include_role:
-#     name: ../roles/kafka_cluster
-#   when: >
-#     ACTION is not defined or
-#     ACTION is none or
-#     ACTION|trim() == "" or
-#     ACTION|trim() == "install"
-# - include_role:
-#     name: ../roles/kafka_cluster
-#     tasks_from: uninstall
-#   when: >
-#     ACTION is defined and
-#     ACTION|trim() == "uninstall"
+2) AMQ Streams Kafka cluster
+- set_fact:
+    namespace: "{{ project_name }}"
+    resources_dir: "{{ resources_base_dir }}/amq-streams"
+    work_dir_name: "kafka_cluster"
+- include_role:
+    name: ../roles/kafka_cluster
+  when: >
+    ACTION is not defined or
+    ACTION is none or
+    ACTION|trim() == "" or
+    ACTION|trim() == "install"
+- include_role:
+    name: ../roles/kafka_cluster
+    tasks_from: uninstall
+  when: >
+    ACTION is defined and
+    ACTION|trim() == "uninstall"
 
-# 3) AMQ Streams Topics
-# - set_fact:
-#     namespace: "{{ project_name }}"
-#     work_dir_name: "kafka_topics"
-# - include_role:
-#     name: ../roles/kafka_topics
-#   when: >
-#     ACTION is not defined or
-#     ACTION is none or
-#     ACTION|trim() == "" or
-#     ACTION|trim() == "install"
-# - include_role:
-#     name: ../roles/kafka_topics
-#     tasks_from: uninstall
-#   when: >
-#     ACTION is defined and
-#     ACTION|trim() == "uninstall"
+3) AMQ Streams Topics
+- set_fact:
+    namespace: "{{ project_name }}"
+    work_dir_name: "kafka_topics"
+- include_role:
+    name: ../roles/kafka_topics
+  when: >
+    ACTION is not defined or
+    ACTION is none or
+    ACTION|trim() == "" or
+    ACTION|trim() == "install"
+- include_role:
+    name: ../roles/kafka_topics
+    tasks_from: uninstall
+  when: >
+    ACTION is defined and
+    ACTION|trim() == "uninstall"
 
 
 
-# # 4) AMQ Streams Kafka-Connect
-# - set_fact:
-#     namespace: "{{ project_name }}"
-#     work_dir_name: "kafka_connect"
-#     resources_dir: "{{ resources_base_dir }}/kafka-connect"
-# - include_role:
-#     name: ../roles/openshift_kafka_connect
-#   when: >
-#     ACTION is not defined or
-#     ACTION is none or
-#     ACTION|trim() == "" or
-#     ACTION|trim() == "install"
-# - include_role:
-#     name: ../roles/openshift_kafka_connect
-#     tasks_from: uninstall
-#   when: >
-#     ACTION is defined and
-#     ACTION|trim() == "uninstall"
+# 4) AMQ Streams Kafka-Connect
+- set_fact:
+    namespace: "{{ project_name }}"
+    work_dir_name: "kafka_connect"
+    resources_dir: "{{ resources_base_dir }}/kafka-connect"
+- include_role:
+    name: ../roles/openshift_kafka_connect
+  when: >
+    ACTION is not defined or
+    ACTION is none or
+    ACTION|trim() == "" or
+    ACTION|trim() == "install"
+- include_role:
+    name: ../roles/openshift_kafka_connect
+    tasks_from: uninstall
+  when: >
+    ACTION is defined and
+    ACTION|trim() == "uninstall"
 
 # 5) Kafdrop
 - set_fact:

--- a/ansible/playbooks/tasks/keda.yml
+++ b/ansible/playbooks/tasks/keda.yml
@@ -1,0 +1,19 @@
+---
+
+- set_fact:
+    namespace: "{{ keda_namepsace }}"
+    resources_dir: "{{ resources_base_dir }}/keda"
+    work_dir_name: keda
+- include_role:
+    name: ../roles/keda
+  when: >
+    ACTION is not defined or
+    ACTION is none or
+    ACTION|trim() == "" or
+    ACTION|trim() == "install"
+- include_role:
+    name: ../roles/keda
+    tasks_from: uninstall
+  when: >
+    ACTION is defined and
+    ACTION|trim() == "uninstall"

--- a/ansible/playbooks/uninstall.yml
+++ b/ansible/playbooks/uninstall.yml
@@ -16,6 +16,7 @@
   - include: tasks/monitoring_operators.yml
   - include: tasks/scm-frontend.yml
   - include: tasks/scm-backend.yml
+  - include: tasks/keda.yml
 #  - include: tasks/knative.yml
   - include: tasks/amq-streams.yml
 

--- a/ansible/resources/keda/keda-controller.yaml
+++ b/ansible/resources/keda/keda-controller.yaml
@@ -1,0 +1,10 @@
+apiVersion: keda.sh/v1alpha1
+kind: KedaController
+metadata:
+  namespace: {{ namespace }}
+  name: {{ keda_controller_name }} 
+spec:
+  logLevel: info
+  logLevelMetrics: '0'
+  watchNamespace: ''
+  logEncoder: console

--- a/ansible/resources/keda/subscription.yml
+++ b/ansible/resources/keda/subscription.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ subscription_name }}
+spec:
+  channel: "{{ subscription_channel }}"
+{% if subscription_automatic_installplan_approval| default(True) | bool %}
+  installPlanApproval: Automatic
+{% else %}
+  installPlanApproval: Manual
+{% endif %}
+  name: {{ subscription_package_name }}
+  source: {{ subscription_catalog_source }}
+  sourceNamespace: {{ subscription_catalog_source_namespace }}
+{% if subscription_starting_csv | default("") | length > 0 %}
+  startingCSV: {{ subscription_starting_csv }}
+{% endif %}

--- a/ansible/resources/scm-backend/scm-backend-service.yml
+++ b/ansible/resources/scm-backend/scm-backend-service.yml
@@ -139,7 +139,7 @@ items:
       app.kubernetes.io/component: {{ application_name }}
       app.kubernetes.io/instance: {{ application_name }}
       app.kubernetes.io/name: {{ application_name }}
-      app.openshift.io/runtime: quarkus
+      app.openshift.io/runtime: camel
       app.openshift.io/runtime-version: 0.0.2
   spec:
     replicas: 1

--- a/ansible/resources/scm-backend/scm-backend-service.yml
+++ b/ansible/resources/scm-backend/scm-backend-service.yml
@@ -22,107 +22,202 @@ items:
       app: {{ application_name }}
     sessionAffinity: None
     type: ClusterIP
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
+# - apiVersion: apps.openshift.io/v1
+#   kind: DeploymentConfig
+#   metadata:
+#     labels:
+#       app: {{ application_name }}
+#     name: {{ application_name }}
+#   spec:
+#     replicas: 1
+#     revisionHistoryLimit: 2
+#     selector:
+#       group: scm
+#       app: {{ application_name }}
+#     strategy:
+#       activeDeadlineSeconds: 21600
+#       resources: {}
+#       rollingParams:
+#         intervalSeconds: 1
+#         maxSurge: 25%
+#         maxUnavailable: 25%
+#         timeoutSeconds: 3600
+#         updatePeriodSeconds: 1
+#       type: Rolling
+#     template:
+#       metadata:
+#         labels:
+#           group: scm
+#           app: {{ application_name }}
+#       spec:
+#         containers:
+#           - env:
+#             - name: KUBERNETES_NAMESPACE
+#               valueFrom:
+#                 fieldRef:
+#                   apiVersion: v1
+#                   fieldPath: metadata.namespace
+#             - name: JAVA_OPTIONS
+#               value: >
+#                 -Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=prometheus
+#             - name: AB_JOLOKIA_OFF
+#               value: 'true'
+#             imagePullPolicy: IfNotPresent
+#             name: {{ application_name }}
+#             ports:
+#               - containerPort: 9779
+#                 name: prometheus
+#                 protocol: TCP
+#             livenessProbe:
+#               failureThreshold: 3
+#               httpGet:
+#                 path: /q/health/live
+#                 port: 8080
+#                 scheme: HTTP
+#               initialDelaySeconds: 30
+#               periodSeconds: 30
+#               timeoutSeconds: 3
+#             readinessProbe:
+#               failureThreshold: 3
+#               httpGet:
+#                 path: /q/health/ready
+#                 port: 8080
+#                 scheme: HTTP
+#               initialDelaySeconds: 30
+#               periodSeconds: 30
+#               timeoutSeconds: 3
+#             resources:
+#               limits:
+#                 cpu: '1500m'
+#                 memory: '1Gi'
+#               requests:
+#                 cpu: '250m'
+#                 memory: '250Mi'
+#             securityContext:
+#               privileged: false
+#             terminationMessagePath: /dev/termination-log
+#             terminationMessagePolicy: File
+#             volumeMounts:
+#             - mountPath: /deployments/config
+#               name: config
+#         dnsPolicy: ClusterFirst
+#         restartPolicy: Always
+#         schedulerName: default-scheduler
+#         securityContext: {}
+#         serviceAccount: {{ application_name }}
+#         serviceAccountName: {{ application_name }}
+#         terminationGracePeriodSeconds: 30
+#         volumes:
+#         - configMap:
+#             defaultMode: 420
+#             items:
+#               - key: {{ application_configmap_key }}
+#                 path: {{ application_configmap_key }}
+#             name: {{ application_configmap }}
+#           name: config
+#     triggers:
+#       - type: ConfigChange
+#       - imageChangeParams:
+#           automatic: true
+#           containerNames:
+#             - {{ application_name }}
+#           from:
+#             kind: ImageStreamTag
+#             name: "{{ application_name }}:{{ service_image_tag }}"
+#         type: ImageChange
+- apiVersion: apps/v1      
+  kind: Deployment
   metadata:
+    annotations:
+      alpha.image.policy.openshift.io/resolve-names: '*'
+      image.openshift.io/triggers: >-
+        [{"from":{"kind":"ImageStreamTag","name":"{{ application_name }}:0.0.2","namespace":"{{ project_name }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"{{ application_name }}\")].image","pause":"false"}]
+      openshift.io/generated-by: OpenShiftWebConsole
+    name: {{ application_name }}
     labels:
       app: {{ application_name }}
-    name: {{ application_name }}
+      app.kubernetes.io/component: {{ application_name }}
+      app.kubernetes.io/instance: {{ application_name }}
+      app.kubernetes.io/name: {{ application_name }}
+      app.openshift.io/runtime: quarkus
+      app.openshift.io/runtime-version: 0.0.2
   spec:
     replicas: 1
-    revisionHistoryLimit: 2
     selector:
-      group: scm
-      app: {{ application_name }}
-    strategy:
-      activeDeadlineSeconds: 21600
-      resources: {}
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 3600
-        updatePeriodSeconds: 1
-      type: Rolling
+      matchLabels:
+        app: {{ application_name }}
     template:
       metadata:
         labels:
-          group: scm
           app: {{ application_name }}
+          deploymentconfig: {{ application_name }}
       spec:
+        volumes:
+          - name: config
+            configMap:
+              name: {{ application_configmap }}
+              items:
+                - key: {{ application_configmap_key }}
+                  path: {{ application_configmap_key }}
+              defaultMode: 420
         containers:
-          - env:
-            - name: KUBERNETES_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: JAVA_OPTIONS
-              value: >
-                -Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=prometheus
-            - name: AB_JOLOKIA_OFF
-              value: 'true'
-            imagePullPolicy: IfNotPresent
-            name: {{ application_name }}
-            ports:
-              - containerPort: 9779
-                name: prometheus
-                protocol: TCP
-            livenessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /q/health/live
-                port: 8080
-                scheme: HTTP
-              initialDelaySeconds: 30
-              periodSeconds: 30
-              timeoutSeconds: 3
+          - resources:
+              limits:
+                cpu: 1500m
+                memory: 1Gi
+              requests:
+                cpu: 250m
+                memory: 250Mi
             readinessProbe:
-              failureThreshold: 3
               httpGet:
                 path: /q/health/ready
                 port: 8080
                 scheme: HTTP
               initialDelaySeconds: 30
-              periodSeconds: 30
               timeoutSeconds: 3
-            resources:
-              limits:
-                cpu: '1500m'
-                memory: '1Gi'
-              requests:
-                cpu: '250m'
-                memory: '250Mi'
-            securityContext:
-              privileged: false
+              periodSeconds: 30
+              failureThreshold: 3
             terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
+            name: {{ application_name }}
+            livenessProbe:
+              httpGet:
+                path: /q/health/live
+                port: 8080
+                scheme: HTTP
+              initialDelaySeconds: 30
+              timeoutSeconds: 3
+              periodSeconds: 30
+              failureThreshold: 3
+            env:
+              - name: JAVA_OPTIONS
+                value: >-
+                  -Dvertx.metrics.options.enabled=true
+                  -Dvertx.metrics.options.registryName=prometheus
+              - name: AB_JOLOKIA_OFF
+                value: 'true'
+              - name: KUBERNETES_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+            ports:
+              - containerPort: 8080
+                protocol: TCP
+              - containerPort: 8443
+                protocol: TCP
+              - name: prometheus
+                containerPort: 9779
+                protocol: TCP
+            imagePullPolicy: IfNotPresent
             volumeMounts:
-            - mountPath: /deployments/config
-              name: config
-        dnsPolicy: ClusterFirst
+              - name: config
+                mountPath: /deployments/config
+            terminationMessagePolicy: File
+            image: >-
+              quay.io/redhat_naps_da/himss_2022_scm-backend-jvm@sha256:0bd900fdc171e7a754403d6bcd8c528bfb51795c29ba0e7384e121f763fdc388
         restartPolicy: Always
-        schedulerName: default-scheduler
-        securityContext: {}
-        serviceAccount: {{ application_name }}
-        serviceAccountName: {{ application_name }}
         terminationGracePeriodSeconds: 30
-        volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: {{ application_configmap_key }}
-                path: {{ application_configmap_key }}
-            name: {{ application_configmap }}
-          name: config
-    triggers:
-      - type: ConfigChange
-      - imageChangeParams:
-          automatic: true
-          containerNames:
-            - {{ application_name }}
-          from:
-            kind: ImageStreamTag
-            name: "{{ application_name }}:{{ service_image_tag }}"
-        type: ImageChange
-
+        dnsPolicy: ClusterFirst
+        securityContext: {}
+        schedulerName: default-scheduler
+        imagePullSecrets: []

--- a/ansible/resources/scm-backend/scm-backend-service.yml
+++ b/ansible/resources/scm-backend/scm-backend-service.yml
@@ -226,6 +226,7 @@ items:
 # KEDA scaledObject
 # will fail if KEDA Operator and KedaController not installed
 #maybe add a flag for installing KEDA?
+#maybe add flafs for pollingINteral, minReplicaCount, lagThreshold
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject

--- a/ansible/resources/scm-backend/scm-backend-service.yml
+++ b/ansible/resources/scm-backend/scm-backend-service.yml
@@ -144,13 +144,14 @@ items:
   spec:
     replicas: 1
     selector:
-      matchLabels:
+      matchLabels: 
+        group: scm
         app: {{ application_name }}
     template:
       metadata:
         labels:
+          group: scm
           app: {{ application_name }}
-          deploymentconfig: {{ application_name }}
       spec:
         volumes:
           - name: config

--- a/ansible/resources/scm-backend/scm-backend-service.yml
+++ b/ansible/resources/scm-backend/scm-backend-service.yml
@@ -22,6 +22,7 @@ items:
       app: {{ application_name }}
     sessionAffinity: None
     type: ClusterIP
+#commenting out for now DC -> Deployment
 # - apiVersion: apps.openshift.io/v1
 #   kind: DeploymentConfig
 #   metadata:
@@ -131,8 +132,7 @@ items:
     annotations:
       alpha.image.policy.openshift.io/resolve-names: '*'
       image.openshift.io/triggers: >-
-        [{"from":{"kind":"ImageStreamTag","name":"{{ application_name }}:0.0.2","namespace":"{{ project_name }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"{{ application_name }}\")].image","pause":"false"}]
-      openshift.io/generated-by: OpenShiftWebConsole
+        [{"from":{"kind":"ImageStreamTag","name":"{{ application_name }}:{{ service_image_tag }}","namespace":"{{ project_name }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"{{ application_name }}\")].image","pause":"false"}]
     name: {{ application_name }}
     labels:
       app: {{ application_name }}
@@ -215,10 +215,39 @@ items:
                 mountPath: /deployments/config
             terminationMessagePolicy: File
             image: >-
-              quay.io/redhat_naps_da/himss_2022_scm-backend-jvm@sha256:0bd900fdc171e7a754403d6bcd8c528bfb51795c29ba0e7384e121f763fdc388
+             {{ service_image }}:{{ service_image_tag }}
         restartPolicy: Always
         terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirst
         securityContext: {}
         schedulerName: default-scheduler
         imagePullSecrets: []
+
+# KEDA scaledObject
+# will fail if KEDA Operator and KedaController not installed
+#maybe add a flag for installing KEDA?
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ application_name }}
+  labels:
+    app: {{ application_name }}
+spec:
+  pollingInterval: 5
+  minReplicaCount: 1
+  scaleTargetRef:
+    # the target has to be a deployment not a deploymentconfig
+    name: '{{ application_name }}'
+    # default is zero
+  triggers:
+    - metadata:
+        # sed/change namepsace
+        bootstrapServers: '{{ kafka_bootstrap_address }}'
+        consumerGroup: scm
+        lagThreshold: '50'
+        # number of pods appears to be roughly lagthreshold/pollinginterval
+        # well at least with this setting it sill load 10 pods
+        offsetResetPolicy: latest
+        topic: '{{ scm_kafka_file_topic }}'
+      type: kafka

--- a/ansible/resources/scm-frontend/scm-frontend-service.yml
+++ b/ansible/resources/scm-frontend/scm-frontend-service.yml
@@ -1,113 +1,83 @@
 ---
-
-kind: List
-apiVersion: v1
-items:
-- apiVersion: v1
-  kind: Service
-  metadata:
-    labels:
-      app: {{ application_name }}
-      monitoring: {{ prometheus_ServiceMonitor_label }}
-      expose: "true"
-    name: {{ application_name }}
-  spec:
-    ports:
-      - name: http
-        port: 8080
-        protocol: TCP
-        targetPort: 8080
-    selector:
-      group: scm 
-      app: {{ application_name }}
-    sessionAffinity: None
-    type: ClusterIP
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
-  metadata:
-    labels:
-      app: {{ application_name }}
-    name: {{ application_name }}
-  spec:
-    replicas: 1
-    revisionHistoryLimit: 2
-    selector:
-      group: scm
-      app: {{ application_name }}
-    strategy:
-      activeDeadlineSeconds: 21600
-      resources: {}
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 3600
-        updatePeriodSeconds: 1
-      type: Rolling
-    template:
-      metadata:
-        labels:
-          group: scm
-          app: {{ application_name }}
-      spec:
-        containers:
-          - env:
-            - name: KUBERNETES_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: {{ application_name }}
+  labels:
+    app.kubernetes.io/component: {{ application_name }}
+    app.kubernetes.io/instance: {{ application_name }}
+    app.kubernetes.io/name: {{ application_name }}
+    app.openshift.io/runtime: camel
+    group: scm
+    # will this propagate to Service?, will this break dashboard
+    monitoring: {{ prometheus_ServiceMonitor_label }}
+    expose: "true"
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: '10'
+        autoscaling.knative.dev/minScale: '1'
+        autoscaling.knative.dev/target: '1' # this means a target of max concurrent request, to reduce autoscale freq, increase number
+        #10 concurrent requests will scale up to 10 pods
+      labels:
+        app.kubernetes.io/component: {{ application_name }}
+        app.kubernetes.io/instance: {{ application_name }}
+        app.kubernetes.io/name: {{ application_name }}
+        app.openshift.io/runtime: camel
+        group: scm
+    spec:
+      containerConcurrency: 10
+      containers:
+        - resources:
+            limits:
+              cpu: 1500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 250Mi
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/ready
+              port: 0
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: {{ application_name }}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/live
+              port: 0
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+          env:
             - name: JAVA_OPTIONS
-              value: >
-                -Dquarkus.config.locations=/deployments/config -Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=prometheus
+              value: >-
+                -Dquarkus.config.locations=/deployments/config
+                -Dvertx.metrics.options.enabled=true
+                -Dvertx.metrics.options.registryName=prometheus
             - name: AB_JOLOKIA_OFF
               value: 'true'
-            imagePullPolicy: IfNotPresent
-            name: {{ application_name }}
-            ports:
-              - containerPort: 9779
-                name: prometheus
-                protocol: TCP
-            livenessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /q/health/live
-                port: 8080
-                scheme: HTTP
-              initialDelaySeconds: 30
-              periodSeconds: 30
-              timeoutSeconds: 3
-            readinessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /q/health/ready
-                port: 8080
-                scheme: HTTP
-              initialDelaySeconds: 30
-              periodSeconds: 30
-              timeoutSeconds: 3
-            resources:
-              limits:
-                cpu: '1500m'
-                memory: '1Gi'
-              requests:
-                cpu: '250m'
-                memory: '250Mi'
-            securityContext:
-              privileged: false
-            terminationMessagePath: /dev/termination-log
-            terminationMessagePolicy: File
-            volumeMounts:
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
             - mountPath: /deployments/config
               name: config
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-        schedulerName: default-scheduler
-        securityContext: {}
-        serviceAccount: {{ application_name }}
-        serviceAccountName: {{ application_name }}
-        terminationGracePeriodSeconds: 30
-        volumes:
+              readOnly: true
+          image: >-
+           {{ service_image }}:{{ service_image_tag }}
+      enableServiceLinks: false
+      timeoutSeconds: 300
+      volumes:
         - configMap:
             defaultMode: 420
             items:
@@ -115,14 +85,133 @@ items:
                 path: {{ application_configmap_key }}
             name: {{ application_configmap }}
           name: config
-    triggers:
-      - type: ConfigChange
-      - imageChangeParams:
-          automatic: true
-          containerNames:
-            - {{ application_name }}
-          from:
-            kind: ImageStreamTag
-            name: "{{ application_name }}:{{ service_image_tag }}"
-        type: ImageChange
+  traffic:
+    - latestRevision: true
+      percent: 100
+
+# kind: List
+# apiVersion: v1
+# items:
+# - apiVersion: v1
+#   kind: Service
+#   metadata:
+#     labels:
+#       app: {{ application_name }}
+#       monitoring: {{ prometheus_ServiceMonitor_label }}
+#       expose: "true"
+#     name: {{ application_name }}
+#   spec:
+#     ports:
+#       - name: http
+#         port: 8080
+#         protocol: TCP
+#         targetPort: 8080
+#     selector:
+#       group: scm 
+#       app: {{ application_name }}
+#     sessionAffinity: None
+#     type: ClusterIP
+# - apiVersion: apps.openshift.io/v1
+#   kind: DeploymentConfig
+#   metadata:
+#     labels:
+#       app: {{ application_name }}
+#     name: {{ application_name }}
+#   spec:
+#     replicas: 1
+#     revisionHistoryLimit: 2
+#     selector:
+#       group: scm
+#       app: {{ application_name }}
+#     strategy:
+#       activeDeadlineSeconds: 21600
+#       resources: {}
+#       rollingParams:
+#         intervalSeconds: 1
+#         maxSurge: 25%
+#         maxUnavailable: 25%
+#         timeoutSeconds: 3600
+#         updatePeriodSeconds: 1
+#       type: Rolling
+#     template:
+#       metadata:
+#         labels:
+#           group: scm
+#           app: {{ application_name }}
+#       spec:
+#         containers:
+#           - env:
+#             - name: KUBERNETES_NAMESPACE
+#               valueFrom:
+#                 fieldRef:
+#                   apiVersion: v1
+#                   fieldPath: metadata.namespace
+#             - name: JAVA_OPTIONS
+#               value: >
+#                 -Dquarkus.config.locations=/deployments/config -Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=prometheus
+#             - name: AB_JOLOKIA_OFF
+#               value: 'true'
+#             imagePullPolicy: IfNotPresent
+#             name: {{ application_name }}
+#             ports:
+#               - containerPort: 9779
+#                 name: prometheus
+#                 protocol: TCP
+#             livenessProbe:
+#               failureThreshold: 3
+#               httpGet:
+#                 path: /q/health/live
+#                 port: 8080
+#                 scheme: HTTP
+#               initialDelaySeconds: 30
+#               periodSeconds: 30
+#               timeoutSeconds: 3
+#             readinessProbe:
+#               failureThreshold: 3
+#               httpGet:
+#                 path: /q/health/ready
+#                 port: 8080
+#                 scheme: HTTP
+#               initialDelaySeconds: 30
+#               periodSeconds: 30
+#               timeoutSeconds: 3
+#             resources:
+#               limits:
+#                 cpu: '1500m'
+#                 memory: '1Gi'
+#               requests:
+#                 cpu: '250m'
+#                 memory: '250Mi'
+#             securityContext:
+#               privileged: false
+#             terminationMessagePath: /dev/termination-log
+#             terminationMessagePolicy: File
+#             volumeMounts:
+#             - mountPath: /deployments/config
+#               name: config
+#         dnsPolicy: ClusterFirst
+#         restartPolicy: Always
+#         schedulerName: default-scheduler
+#         securityContext: {}
+#         serviceAccount: {{ application_name }}
+#         serviceAccountName: {{ application_name }}
+#         terminationGracePeriodSeconds: 30
+#         volumes:
+#         - configMap:
+#             defaultMode: 420
+#             items:
+#               - key: {{ application_configmap_key }}
+#                 path: {{ application_configmap_key }}
+#             name: {{ application_configmap }}
+#           name: config
+#     triggers:
+#       - type: ConfigChange
+#       - imageChangeParams:
+#           automatic: true
+#           containerNames:
+#             - {{ application_name }}
+#           from:
+#             kind: ImageStreamTag
+#             name: "{{ application_name }}:{{ service_image_tag }}"
+#         type: ImageChange
 

--- a/ansible/roles/keda/defaults/main.yml
+++ b/ansible/roles/keda/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# keda operator
+keda_operator_subscription_template: subscription.yml
+keda_operator_packagemanifest: keda
+keda_operator_deployment_name: keda-olm-operator
+keda_operator_subscription_name: keda
+keda_operator_subscription_channel: alpha
+keda_operator_subscription_automatic_installplan_approval: false
+keda_operator_subscription_starting_csv: "keda.v2.6.1"
+# keda_operator_subscription_package_name
+keda_operator_subscription_catalog_source: community-operators
+keda_operator_subscription_catalog_source_namespace: openshift-marketplace
+keda_operator_csv_prefix: keda
+
+# KedaController CR
+keda_controller_name: keda

--- a/ansible/roles/keda/defaults/main.yml
+++ b/ansible/roles/keda/defaults/main.yml
@@ -14,3 +14,4 @@ keda_operator_csv_prefix: keda
 
 # KedaController CR
 keda_controller_name: keda
+keda_controller_template: keda-controller.yaml

--- a/ansible/roles/keda/meta/main.yml
+++ b/ansible/roles/keda/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - role: work_dir

--- a/ansible/roles/keda/tasks/main.yml
+++ b/ansible/roles/keda/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for keda
 
-# create keda namespace
 - name: create project {{ namespace }}
   oc_project:
     state: present
@@ -49,4 +48,25 @@
       r_keda_operator_deployment.ansible_module_results.results[0].status.readyReplicas ==
       r_keda_operator_deployment.ansible_module_results.results[0].status.replicas
 
-#create keda controller
+- name: copy kedacontroller template
+  template:
+    src: "{{ resources_dir }}/{{ keda_controller_template }}"
+    dest: "{{ work_dir }}/{{ keda_controller_template }}"
+
+- name: check if KedaController {{ keda_controller_name }} is deployed
+  oc_obj:
+    oc_binary: "{{ openshift_cli }}"
+    state: list
+    namespace: "{{ namespace }}"
+    name: "{{ keda_controller_name }}"
+    kind: kedacontrollers.keda.sh
+  register: result
+
+- name: "create KedaController CR {{ keda_controller_name }} in {{ namespace }}"
+  oc_list:
+    oc_binary: "{{ openshift_cli }}"
+    state: present
+    namespace: "{{ keda_controller_name }}"
+    files:
+      - "{{ work_dir }}/{{ keda_controller_template }}"
+  when: result.ansible_module_results.stderr is defined and result.ansible_module_results.stderr != ""

--- a/ansible/roles/keda/tasks/main.yml
+++ b/ansible/roles/keda/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+# tasks file for keda
+
+# create keda namespace
+- name: create project {{ namespace }}
+  oc_project:
+    state: present
+    oc_binary: "{{ openshift_cli }}"
+    name: "{{ namespace }}"
+
+- name: "create operatorgroup in {{ namespace }}"
+  import_role:
+    name: ../roles/operatorgroup
+  vars:
+    operatorgroup_name: "{{ namespace }}"
+    operatorgroup_namespace: "{{ namespace }}"
+    # operatorgroup_target_namespace: "{{ namespace }}"
+
+- name: "deploy keda operator in {{ namespace }}"
+  import_role:
+    name: ../roles/operator_olm
+  vars:
+    operator_name: keda-operator
+    packagemanifest: "{{ keda_operator_packagemanifest }}"
+    subscription_channel: "{{ keda_operator_subscription_channel }}"
+    subscription_namespace: "{{ namespace }}"
+    subscription_name: "{{ keda_operator_subscription_name }}"
+    automatic_installplan_approval: "{{ keda_operator_subscription_automatic_installplan_approval }}"
+    subscription_starting_csv: "{{ keda_operator_subscription_starting_csv }}"
+    subscription_catalog_source: "{{ keda_operator_subscription_catalog_source}}"
+    subscription_catalog_source_namespace: "{{ keda_operator_subscription_catalog_source_namespace }}"
+    csv_prefix: "{{ keda_operator_csv_prefix }}"
+
+- name: "wait until keda operator is active in {{ namespace }}"
+  oc_obj:
+    state: list
+    oc_binary: "{{ openshift_cli }}"
+    kind: Deployment
+    name: "{{ keda_operator_deployment_name }}"
+    namespace: "{{ namespace }}"
+  register: r_keda_operator_deployment
+  retries: 30
+  delay: 10
+  changed_when: false
+  until:
+    - r_keda_operator_deployment.ansible_module_results.results[0].status.readyReplicas is defined
+    - r_keda_operator_deployment.ansible_module_results.results[0].status.replicas is defined
+    - >-
+      r_keda_operator_deployment.ansible_module_results.results[0].status.readyReplicas ==
+      r_keda_operator_deployment.ansible_module_results.results[0].status.replicas
+
+#create keda controller

--- a/ansible/roles/keda/tasks/main.yml
+++ b/ansible/roles/keda/tasks/main.yml
@@ -13,7 +13,7 @@
   vars:
     operatorgroup_name: "{{ namespace }}"
     operatorgroup_namespace: "{{ namespace }}"
-    # operatorgroup_target_namespace: "{{ namespace }}"
+    operatorgroup_target_namespace: ""
 
 - name: "deploy keda operator in {{ namespace }}"
   import_role:

--- a/ansible/roles/keda/tasks/uninstall.yaml
+++ b/ansible/roles/keda/tasks/uninstall.yaml
@@ -1,5 +1,12 @@
 
-#delete KedaController
+- name: "delete KedaController in {{ namespace }}"
+  oc_obj:
+    state: absent
+    oc_binary: "{{ openshift_cli }}"
+    name: keda
+    namespace: "{{ namespace }}"
+    kind: kedacontrollers.keda.sh
+
 
 - name: "delete keda operator in {{ namespace }}"
   import_role:

--- a/ansible/roles/keda/tasks/uninstall.yaml
+++ b/ansible/roles/keda/tasks/uninstall.yaml
@@ -1,0 +1,18 @@
+
+#delete KedaController
+
+- name: "delete keda operator in {{ namespace }}"
+  import_role:
+    name: ../roles/operator_olm
+    tasks_from: uninstall
+  vars:
+    operator_name: keda-operator
+    subscription_namespace: "{{ namespace }}"
+    subscription_name: "{{ keda_operator_subscription_name }}"
+    csv_prefix: "{{ keda_operator_csv_prefix }}"
+
+- name: "delete project {{ namespace }}"
+  oc_project:
+    oc_binary: "{{ openshift_cli }}"
+    state: absent
+    name: "{{ namespace }}"

--- a/ansible/roles/keda/vars/main.yml
+++ b/ansible/roles/keda/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for keda

--- a/ansible/roles/scm-backend/tasks/deploy_from_image.yml
+++ b/ansible/roles/scm-backend/tasks/deploy_from_image.yml
@@ -29,7 +29,9 @@
     state: list
     namespace: "{{ namespace }}"
     name: "{{ application_name }}"
-    kind: dc
+    #commenting out for now DC -> Deployment
+    # kind: dc
+    kind: deployment
   register: result
 
 - name: deploy {{ application_name }} application
@@ -42,7 +44,9 @@
   when: result.ansible_module_results.stderr is defined and result.ansible_module_results.stderr != ""
 
 - name: "wait until {{ application_name }} application is up and running"
-  shell: "{{ openshift_cli }} get dc {{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
+#commenting out for now DC -> Deployment
+  #shell: "{{ openshift_cli }} get dc {{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
+  shell: "{{ openshift_cli }} get deployment {{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
   vars:
     json_template: '\{\{.status.readyReplicas\}\}'
   register: result

--- a/ansible/roles/scm-backend/tasks/uninstall.yml
+++ b/ansible/roles/scm-backend/tasks/uninstall.yml
@@ -6,7 +6,9 @@
     state: absent
     name: "{{ application_name }}"
     namespace: "{{ namespace }}"
-    kind: dc
+    #commenting out for now DC -> Deployment
+    #kind: dc
+    kind: deployment
 
 - name: delete service
   oc_obj:
@@ -83,3 +85,11 @@
     namespace: "{{ namespace }}"
   when: undeploy_psql_scm is defined and undeploy_psql_scm == "true"
 
+#uncomment when  we add KEDA scaling
+- name: delete KEDA scaled object
+  oc_obj:
+    oc_binary: "{{ openshift_cli }}"
+    state: absent
+    name: "{{ application_name }}"
+    namespace: "{{ namespace }}"
+    kind: scaledobjects.keda.sh

--- a/ansible/roles/scm-frontend/tasks/deploy_from_image.yml
+++ b/ansible/roles/scm-frontend/tasks/deploy_from_image.yml
@@ -54,7 +54,7 @@
 #   delay: 30
 #   changed_when: false
 
-# not the best check but deployment based on selector not working
+# not the best check but deployment based on selector not working..try jsonpath instead
 - name: "wait until {{ application_name }} application is up and running"
   shell: "{{ openshift_cli }} get ksvc {{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
   vars:

--- a/ansible/roles/scm-frontend/tasks/deploy_from_image.yml
+++ b/ansible/roles/scm-frontend/tasks/deploy_from_image.yml
@@ -29,7 +29,9 @@
     state: list
     namespace: "{{ namespace }}"
     name: "{{ application_name }}"
-    kind: dc
+    # dc to ksvc
+    #kind: dc
+    kind: ksvc
   register: result
 
 - name: deploy {{ application_name }} application
@@ -41,12 +43,25 @@
       - "{{ work_dir }}/{{ application_template }}"
   when: result.ansible_module_results.stderr is defined and result.ansible_module_results.stderr != ""
 
+# - name: "wait until {{ application_name }} application is up and running"
+#   #shell: "{{ openshift_cli }} get dc {{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
+#   shell: "{{ openshift_cli }} get deployment -lapp.kubernetes.io/name={{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
+#   vars:
+#     json_template: '\{\{.status.readyReplicas\}\}'
+#   register: result
+#   until: result.stdout == "1"
+#   retries: 10
+#   delay: 30
+#   changed_when: false
+
+# not the best check but deployment based on selector not working
 - name: "wait until {{ application_name }} application is up and running"
-  shell: "{{ openshift_cli }} get dc {{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
+  shell: "{{ openshift_cli }} get ksvc {{ application_name }} -o template --template={{ json_template }} -n {{ namespace }}"
   vars:
-    json_template: '\{\{.status.readyReplicas\}\}'
+    json_template: '\{\{.status.address.url\}\}'
   register: result
-  until: result.stdout == "1"
+  # need to fix this condition
+  until: result.stdout != ""
   retries: 10
   delay: 30
   changed_when: false

--- a/ansible/roles/scm-frontend/tasks/main.yml
+++ b/ansible/roles/scm-frontend/tasks/main.yml
@@ -39,20 +39,21 @@
 - import_tasks: deploy_from_image.yml
   when: deploy_from is defined and deploy_from == "image"
 
-- set_fact:
-    route_hostname: "{{ application_name }}-{{ namespace }}.{{ ocp_domain_host.stdout }}"
-- name: "copy route template"
-  template:
-    src: "{{ resources_dir }}/route.yml"
-    dest: "{{ work_dir }}/route.yml"
-- name: "deploy {{ application_name }} route {{ route_hostname }}"
-  oc_obj:
-    state: present
-    oc_binary: "{{ openshift_cli }}"
-    name: "{{ application_name }}"
-    namespace: "{{ namespace }}"
-    kind: route
-    files:
-      - "{{ work_dir }}/route.yml"
+#knative service will create route
+# - set_fact:
+#     route_hostname: "{{ application_name }}-{{ namespace }}.{{ ocp_domain_host.stdout }}"
+# - name: "copy route template"
+#   template:
+#     src: "{{ resources_dir }}/route.yml"
+#     dest: "{{ work_dir }}/route.yml"
+# - name: "deploy {{ application_name }} route {{ route_hostname }}"
+#   oc_obj:
+#     state: present
+#     oc_binary: "{{ openshift_cli }}"
+#     name: "{{ application_name }}"
+#     namespace: "{{ namespace }}"
+#     kind: route
+#     files:
+#       - "{{ work_dir }}/route.yml"
 
 ###########################################################

--- a/ansible/roles/scm-frontend/tasks/uninstall.yml
+++ b/ansible/roles/scm-frontend/tasks/uninstall.yml
@@ -1,20 +1,22 @@
 ---
 
-- name: delete deployment config
+#- name: delete deployment config
+- name: delete knative service
   oc_obj:
     oc_binary: "{{ openshift_cli }}"
     state: absent
     name: "{{ application_name }}"
     namespace: "{{ namespace }}"
-    kind: dc
+    #kind: dc
+    kind: ksvc
 
-- name: delete service
-  oc_obj:
-    oc_binary: "{{ openshift_cli }}"
-    state: absent
-    name: "{{ application_name }}"
-    namespace: "{{ namespace }}"
-    kind: service
+# - name: delete service
+#   oc_obj:
+#     oc_binary: "{{ openshift_cli }}"
+#     state: absent
+#     name: "{{ application_name }}"
+#     namespace: "{{ namespace }}"
+#     kind: service
 
 - name: delete imagestream in the {{ namespace }} project
   oc_obj:

--- a/load-generator/README.md
+++ b/load-generator/README.md
@@ -1,12 +1,23 @@
 # SCM Load Test Generator
 This generates test data and then uploads that test data to some server using curl.
 
-## Building
+## Running 
+```
+SCM_FRONTEND=$(oc get ksvc scm-frontend -o template --template='{{.status.url}}')
+docker run --rm --name scm-datagen -e SCM_UPLOAD_TIMES=10 -e SCM_URL=$SCM_FRONTEND/gzippedFiles quay.io/redhat_naps_da/scm-datagen
+```
+
+`SCM_UPLOAD_TIMES` is the number of times to upload an AM3X and DETM tgz (uploading both counts as 1 time).
+`SCM_URL` is the api endpoint to upload the document to.
+
+## Building and Running locally
+
+### Building locally
 ```
 docker build -t quay.io/jkeam/scm-datagen -f ./Dockerfile .
 ```
 
-## Running
+### Running locally
 ```
 docker run --rm --name scm-datagen -e SCM_UPLOAD_TIMES=10 -e SCM_URL=http://localhost:8180/gzippedFiles quay.io/jkeam/scm-datagen
 ```

--- a/scm-backend/src/main/kubernetes/Readme.md
+++ b/scm-backend/src/main/kubernetes/Readme.md
@@ -1,5 +1,5 @@
 ## Prerequisites
-Install the `KEDA` Operator from OperatorHub, and create a `KedaController` (see below) in the generated keda namespace before applying scm-backend-deployment.yml
+Install the `KEDA` Operator from OperatorHub, and create a `KedaController` (see below) in the generated keda namespace before applying 'scm-backend-deployment.yml'. `scm-scaled-deployment.yml` is the scm-backend as a `Deployment` rather than `DeploymentConfig`
 
 ```
 apiVersion: keda.sh/v1alpha1

--- a/scm-backend/src/main/kubernetes/Readme.md
+++ b/scm-backend/src/main/kubernetes/Readme.md
@@ -1,0 +1,15 @@
+## Prerequisites
+Install the `KEDA` Operator from OperatorHub, and create a `KedaController` (see below) in the generated keda namespace
+
+```
+apiVersion: keda.sh/v1alpha1
+kind: KedaController
+metadata:
+  namespace: keda
+  name: keda
+spec:
+  logLevel: info
+  logLevelMetrics: '0'
+  watchNamespace: ''
+  logEncoder: console
+```

--- a/scm-backend/src/main/kubernetes/Readme.md
+++ b/scm-backend/src/main/kubernetes/Readme.md
@@ -1,5 +1,5 @@
 ## Prerequisites
-Install the `KEDA` Operator from OperatorHub, and create a `KedaController` (see below) in the generated keda namespace
+Install the `KEDA` Operator from OperatorHub, and create a `KedaController` (see below) in the generated keda namespace before applying scm-backend-deployment.yml
 
 ```
 apiVersion: keda.sh/v1alpha1

--- a/scm-backend/src/main/kubernetes/kafka-scaledobject.yml
+++ b/scm-backend/src/main/kubernetes/kafka-scaledobject.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: kafka-scaledobject
+spec:
+  pollingInterval: 5
+  scaleTargetRef:
+    # the target has to be a deployment not a deploymentconfig
+    name: scm-backend
+    minReplicaCount: 1 # default is zero
+  triggers:
+    - metadata:
+        # sed/change namepsace
+        bootstrapServers: 'kafka-cluster-kafka-bootstrap.user1-himss2022-scm.svc:9092'
+        consumerGroup: scm
+        lagThreshold: '50'
+        # number of pods appears to be roughly lagthreshold/pollinginterval
+        # well at least with this setting it sill load 10 pods
+        offsetResetPolicy: latest
+        topic: topic-scm-file
+      type: kafka
+#spec; https://keda.sh/docs/1.4/concepts/scaling-deployments/

--- a/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
+++ b/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
@@ -1,0 +1,98 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+    deployment.kubernetes.io/revision: '6'
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"scm-backend:0.0.2","namespace":"user1-himss2022-scm"},"fieldPath":"spec.template.spec.containers[?(@.name==\"scm-backend\")].image","pause":"false"}]
+    openshift.io/generated-by: Opme: scm-backend
+  labels:
+    app: scm-backend
+    app.kubernetes.io/component: scm-backend
+    app.kubernetes.io/instance: scm-backend
+    app.kubernetes.io/name: scm-backend
+    app.openshift.io/runtime: quarkus
+    app.openshift.io/runtime-version: 0.0.2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scm-backend
+  template:
+    metadata:
+      labels:
+        app: scm-backend
+        deploymentconfig: scm-backend
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: scm-backend
+            items:
+              - key: application.properties
+                path: application.properties
+            defaultMode: 420
+      containers:
+        - resources:
+            limits:
+              cpu: 1500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 250Mi
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 3
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: scm-backend
+          livenessProbe:
+            httpGet:
+              path: /q/health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 3
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: JAVA_OPTIONS
+              value: >-
+                -Dvertx.metrics.options.enabled=true
+                -Dvertx.metrics.options.registryName=prometheus
+            - name: AB_JOLOKIA_OFF
+              value: 'true'
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+            - name: prometheus
+              containerPort: 9779
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config
+              mountPath: /deployments/config
+          terminationMessagePolicy: File
+          image: >-
+            quay.io/redhat_naps_da/himss_2022_scm-backend-jvm@sha256:0bd900fdc171e7a754403d6bcd8c528bfb51795c29ba0e7384e121f763fdc388
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+      imagePullSecrets: []

--- a/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
+++ b/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
@@ -6,13 +6,13 @@ metadata:
     deployment.kubernetes.io/revision: '6'
     image.openshift.io/triggers: >-
       [{"from":{"kind":"ImageStreamTag","name":"scm-backend:0.0.2","namespace":"user1-himss2022-scm"},"fieldPath":"spec.template.spec.containers[?(@.name==\"scm-backend\")].image","pause":"false"}]
-    openshift.io/generated-by: Opme: scm-backend
+    name: scm-backend
   labels:
     app: scm-backend
     app.kubernetes.io/component: scm-backend
     app.kubernetes.io/instance: scm-backend
     app.kubernetes.io/name: scm-backend
-    app.openshift.io/runtime: quarkus
+    app.openshift.io/runtime: camel
     app.openshift.io/runtime-version: 0.0.2
 spec:
   replicas: 1

--- a/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
+++ b/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
@@ -18,12 +18,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      group: scm
       app: scm-backend
   template:
     metadata:
       labels:
         app: scm-backend
-        deploymentconfig: scm-backend
+        group: scm
     spec:
       volumes:
         - name: config

--- a/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
+++ b/scm-backend/src/main/kubernetes/scm-backend-deployment.yml
@@ -6,7 +6,7 @@ metadata:
     deployment.kubernetes.io/revision: '6'
     image.openshift.io/triggers: >-
       [{"from":{"kind":"ImageStreamTag","name":"scm-backend:0.0.2","namespace":"user1-himss2022-scm"},"fieldPath":"spec.template.spec.containers[?(@.name==\"scm-backend\")].image","pause":"false"}]
-    name: scm-backend
+  name: scm-backend
   labels:
     app: scm-backend
     app.kubernetes.io/component: scm-backend
@@ -95,4 +95,4 @@ spec:
       dnsPolicy: ClusterFirst
       securityContext: {}
       schedulerName: default-scheduler
-      imagePullSecrets: []
+      imagePullSecrets: []            

--- a/scm-backend/src/main/kubernetes/scm-backend-kafka-scaledobject.yml
+++ b/scm-backend/src/main/kubernetes/scm-backend-kafka-scaledobject.yml
@@ -2,13 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: kafka-scaledobject
+  name: scm-bacnkend-kafka-scaledobject
 spec:
   pollingInterval: 5
+  minReplicaCount: 1
   scaleTargetRef:
     # the target has to be a deployment not a deploymentconfig
     name: scm-backend
-    minReplicaCount: 1 # default is zero
+    # default is zero
   triggers:
     - metadata:
         # sed/change namepsace

--- a/scm-backend/src/main/kubernetes/scm-backend-kafka-scaledobject.yml
+++ b/scm-backend/src/main/kubernetes/scm-backend-kafka-scaledobject.yml
@@ -3,6 +3,8 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: scm-backend
+  labels:
+    app: scm-backend
 spec:
   pollingInterval: 5
   minReplicaCount: 1

--- a/scm-backend/src/main/kubernetes/scm-backend-kafka-scaledobject.yml
+++ b/scm-backend/src/main/kubernetes/scm-backend-kafka-scaledobject.yml
@@ -2,7 +2,7 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: scm-bacnkend-kafka-scaledobject
+  name: scm-backend
 spec:
   pollingInterval: 5
   minReplicaCount: 1

--- a/scm-frontend/src/main/kubernetes/Readme.md
+++ b/scm-frontend/src/main/kubernetes/Readme.md
@@ -1,0 +1,2 @@
+## Prerequisites
+Install OpenShift Serverless version >= 1.19 - Knative Serving

--- a/scm-frontend/src/main/kubernetes/Readme.md
+++ b/scm-frontend/src/main/kubernetes/Readme.md
@@ -1,2 +1,2 @@
 ## Prerequisites
-Install OpenShift Serverless version >= 1.19 - Knative Serving
+Install OpenShift Serverless version >= 1.19 - Knative Serving before deploying scm-frontend-knative-service.yaml

--- a/scm-frontend/src/main/kubernetes/Readme.md
+++ b/scm-frontend/src/main/kubernetes/Readme.md
@@ -1,2 +1,2 @@
 ## Prerequisites
-Install OpenShift Serverless version >= 1.19 - Knative Serving before deploying scm-frontend-knative-service.yaml
+Install OpenShift Serverless version >= 1.19 - Knative Serving before deploying the KNative service defined in`scm-frontend-knative-service.yaml`

--- a/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
+++ b/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
@@ -1,0 +1,198 @@
+# oc get routes.serving.knative.dev -n user1-himss2022-scm 
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: scm-frontend
+  labels:
+    app.kubernetes.io/component: scm-frontend
+    app.kubernetes.io/instance: scm-frontend
+    app.kubernetes.io/name: scm-frontend
+    app.openshift.io/runtime: camel
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: '10'
+        autoscaling.knative.dev/minScale: '1'
+        autoscaling.knative.dev/target: '1' # this means a target of max concurrent request, to reduce autoscale freq, increase number
+        #10 concurrent requests will scale up to 10 pods
+      labels:
+        app.kubernetes.io/component: scm-frontend
+        app.kubernetes.io/instance: scm-frontend
+        app.kubernetes.io/name: scm-frontend
+        app.openshift.io/runtime: camel
+    spec:
+      containerConcurrency: 10
+      containers:
+        - resources:
+            limits:
+              cpu: 1500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 250Mi
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/ready
+              port: 0
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+          name: scm-frontend
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/live
+              port: 0
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 3
+          env:
+            - name: JAVA_OPTIONS
+              value: >-
+                -Dquarkus.config.locations=/deployments/config
+                -Dvertx.metrics.options.enabled=true
+                -Dvertx.metrics.options.registryName=prometheus
+            - name: AB_JOLOKIA_OFF
+              value: 'true'
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /deployments/config
+              name: config
+              readOnly: true
+          image: >-
+            quay.io/redhat_naps_da/himss_2022_scm-frontend-jvm@sha256:d43e631b77f8c91502a053097807bcdca4b451cc78da2b68583fc32ad9fb82f0
+      enableServiceLinks: false
+      timeoutSeconds: 300
+      volumes:
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: application.properties
+                path: application.properties
+            name: scm-frontend
+          name: config
+  traffic:
+    - latestRevision: true
+      percent: 100
+# ---
+# kind: DeploymentConfig
+# apiVersion: apps.openshift.io/v1
+# metadata:
+#   name: scm-frontend
+#   labels:
+#     app: scm-frontend
+# spec:
+#   strategy:
+#     type: Rolling
+#     resources: {}
+#     activeDeadlineSeconds: 21600
+#     rollingParams:
+#       timeoutSeconds: 3600
+#       updatePeriodSeconds: 1
+#       intervalSeconds: 1
+#       maxSurge: 25%
+#       maxUnavailable: 25%
+#   triggers:
+#     - type: ImageChange
+#       imageChangeParams:
+#         automatic: true
+#         containerNames:
+#           - scm-frontend
+#         from:
+#           kind: ImageStreamTag
+#           name: 'scm-frontend:0.0.1'
+#           namespace: user1-himss2022-scm
+#     - type: ConfigChange
+#   replicas: 1
+#   test: false
+#   selector:
+#     app: scm-frontend
+#     group: scm
+#   template:
+#     metadata:
+#       labels:
+#         app: scm-frontend
+#         group: scm
+#     spec:
+#       restartPolicy: Always
+#       serviceAccountName: scm-frontend
+#       schedulerName: default-scheduler
+#       terminationGracePeriodSeconds: 30
+#       securityContext: {}
+#       containers:
+#         - resources:
+#             limits:
+#               cpu: 1500m
+#               memory: 1Gi
+#             requests:
+#               cpu: 250m
+#               memory: 250Mi
+#           readinessProbe:
+#             httpGet:
+#               path: /q/health/ready
+#               port: 8080
+#               scheme: HTTP
+#             initialDelaySeconds: 30
+#             timeoutSeconds: 3
+#             periodSeconds: 30
+#             successThreshold: 1
+#             failureThreshold: 3
+#           terminationMessagePath: /dev/termination-log
+#           name: scm-frontend
+#           livenessProbe:
+#             httpGet:
+#               path: /q/health/live
+#               port: 8080
+#               scheme: HTTP
+#             initialDelaySeconds: 30
+#             timeoutSeconds: 3
+#             periodSeconds: 30
+#             successThreshold: 1
+#             failureThreshold: 3
+#           env:
+#             - name: KUBERNETES_NAMESPACE
+#               valueFrom:
+#                 fieldRef:
+#                   apiVersion: v1
+#                   fieldPath: metadata.namespace
+#             - name: JAVA_OPTIONS
+#               value: >
+#                 -Dquarkus.config.locations=/deployments/config
+#                 -Dvertx.metrics.options.enabled=true
+#                 -Dvertx.metrics.options.registryName=prometheus
+#             - name: AB_JOLOKIA_OFF
+#               value: 'true'
+#           securityContext:
+#             privileged: false
+#           ports:
+#             - name: prometheus
+#               containerPort: 9779
+#               protocol: TCP
+#           imagePullPolicy: IfNotPresent
+#           volumeMounts:
+#             - name: config
+#               mountPath: /deployments/config
+#           terminationMessagePolicy: File
+#           image: >-
+#             quay.io/redhat_naps_da/himss_2022_scm-frontend-jvm@sha256:d43e631b77f8c91502a053097807bcdca4b451cc78da2b68583fc32ad9fb82f0
+#       serviceAccount: scm-frontend
+#       volumes:
+#         - name: config
+#           configMap:
+#             name: scm-frontend
+#             items:
+#               - key: application.properties
+#                 path: application.properties
+#             defaultMode: 420
+#       dnsPolicy: ClusterFirst
+#       imagePullSecrets: []

--- a/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
+++ b/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
@@ -1,4 +1,4 @@
-# oc get routes.serving.knative.dev -n user1-himss2022-scm 
+# oc get routes.serving.knative.dev scm-frontend -n user1-himss2022-scm 
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
+++ b/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
@@ -1,5 +1,5 @@
 # oc get routes.serving.knative.dev scm-frontend -n user1-himss2022-scm 
-# SCM_FRONTEND=oc get ksvc scm-frontend -o template --template='{{.status.url}}'
+# SCM_FRONTEND=$(oc get ksvc scm-frontend -o template --template='{{.status.url}}')
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
+++ b/scm-frontend/src/main/kubernetes/scm-frontend-knative-service.yaml
@@ -1,4 +1,5 @@
 # oc get routes.serving.knative.dev scm-frontend -n user1-himss2022-scm 
+# SCM_FRONTEND=oc get ksvc scm-frontend -o template --template='{{.status.url}}'
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -9,6 +10,10 @@ metadata:
     app.kubernetes.io/instance: scm-frontend
     app.kubernetes.io/name: scm-frontend
     app.openshift.io/runtime: camel
+    group: scm
+    # will this propagate to Service?, will this break dashboard
+    monitoring: prometheus
+    expose: "true"
 spec:
   template:
     metadata:
@@ -22,6 +27,7 @@ spec:
         app.kubernetes.io/instance: scm-frontend
         app.kubernetes.io/name: scm-frontend
         app.openshift.io/runtime: camel
+        group: scm
     spec:
       containerConcurrency: 10
       containers:


### PR DESCRIPTION
1) Created and tested example CRs in the scm-frontend and scm-backend src/main/kubernetes folder
NOTE: we can remove these once all ansible installer changes are completed
a) added knative service CR for frontend scaling
b) for the backend scaling, utilized KEDA since knative right now only scales http-based services
Added ScaledObject CR
Changed scm-backend to a Deployment since DeploymentConfig doesn't seem to be supported for KEDA scaling

2) Updated Ansible Installer to test the changes in (1)
a) Backend
since keda needs a Deployment as the scaling target change backend to use Deployment CR
added CR for keda scaled object 
b) Frontend
added knative for frontend
c) added automated ansible install of KEDA

Code Changes to install Knative  To test this branch, install Knative Scaling before running the ansible script